### PR TITLE
Remove case sensitivity from setColor

### DIFF
--- a/src/myr/Myr.js
+++ b/src/myr/Myr.js
@@ -417,7 +417,7 @@ class Myr {
     };
 
     setColor = (color) => {
-        this.cursor.color = color;
+        this.cursor.color = color.toLowerCase();
         return this.cursor.color;
     }
 


### PR DESCRIPTION
I was able to edit the setColor function by adding .toLowerCase so it allows the user to enter both uppercase and lowercase letters and automatically sets the capital letters to lowercase internally.
