### PR TITLE
Copyright Footer Fixes

### DIFF
--- a/src/components/structural/Footer.js
+++ b/src/components/structural/Footer.js
@@ -23,12 +23,12 @@ class Footer extends Component {
                         </ul>
                     </div>
                     <div className="col-lg-4 d-none d-md-block text-center">
-                        <div>© 2020 -<span>&nbsp;</span>
+                        <div>© 2018 - {new Date().getFullYear()}<span>&nbsp;</span>
                             <a href="https://sites.uml.edu/engaging-computing/" target="_blank" rel="noopener noreferrer">University of Massachusetts Lowell, Engaging Computing Group</a>
                         </div>
                     </div>
                     <div className="col-sm-12 d-block d-md-none text-center">
-                        <div>© 2020 -<br />
+                        <div>© 2018 - {new Date().getFullYear()}<br />
                             <a href="https://sites.uml.edu/engaging-computing/" target="_blank" rel="noopener noreferrer">University of Massachusetts Lowell,<br />Engaging Computing Group</a>
                         </div>
                     </div>


### PR DESCRIPTION
This updates the footer to show `2018 - <current year>` for the copyright notice in the footer.  Since this is using JavaScript's `Date` functionality, this should be a one and done fix.

This will close #448 