### PR TITLE
Fixed description of "getMagnitude" not showing on the reference

### DIFF
--- a/src/myr/reference.js
+++ b/src/myr/reference.js
@@ -521,7 +521,7 @@ let animations = [
     {
         name: "getMagnitude",
         parameters: [],
-        desription: <span>The getMagnitude function returns the current magnitude attribute of the cursor. The magnitude can be changed by the setMagnitude function.</span>
+        description: <span>The getMagnitude function returns the current magnitude attribute of the cursor. The magnitude can be changed by the setMagnitude function.</span>
     },
     {
         name: "spin",


### PR DESCRIPTION
There's a typo in the "description", so the description of the "getMagnitude" is not showing in the reference.