### PR TITLE
Move the cursor to middle of parenthesis when select function from auto complete

### DIFF
--- a/src/components/editor/customCompleter.js
+++ b/src/components/editor/customCompleter.js
@@ -224,8 +224,6 @@ export const customCompleter = {
             };
         }));
 
-        
-
         callback(null, Colors.map(function (word) {
             return {
                 caption: word,

--- a/src/components/editor/customCompleter.js
+++ b/src/components/editor/customCompleter.js
@@ -213,9 +213,18 @@ export const customCompleter = {
                 caption: word,
                 value: word,
                 meta: "MYR",
-                score: 2
+                score: 2,
+                completer:{
+                    insertMatch: function(editor,data){
+                        editor.completer.insertMatch({value:data.value});
+                        let pos = editor.selection.getCursor();
+                        editor.gotoLine(pos.row+1,pos.column-1); 
+                    }
+                }
             };
         }));
+
+        
 
         callback(null, Colors.map(function (word) {
             return {


### PR DESCRIPTION
This is a little enhancement made to the autocomplete that when user select a MYR function (eg. setPosition()) from autocomplete, it will move cursor to middle of the parenthesis instead at end to remove some frustration.