### PR TITLE
Changed scale of the grid so that it lines up with positioning

### DIFF
--- a/src/components/structural/View.js
+++ b/src/components/structural/View.js
@@ -354,7 +354,7 @@ class View extends Component {
         if (this.props.sceneConfig.settings.showCoordHelper) {
             return (
                 <Fragment>
-                    <a-grid height="53.33" width="53.33" position="-0.5 -0.26 -0.5" scale="1.5 1.5 1.5" material="shader:flat;" gridmaterial/>
+                    <a-grid height="53.33" width="53.33" position="-0.5 -0.26 -0.5" scale="1.4 1.4 1.4" material="shader:flat;" gridmaterial/>
                     <a-tube path="-35 -0.2 0, 35 -0.2 0" radius="0.05" material="color: red; shader:flat;"></a-tube>
                     <a-tube path="0 -0.2 -35, 0 -0.2 35" radius="0.05" material="color: blue; shader:flat;"></a-tube>
                     <a-tube path="0 -35 0, 0 35 0" radius="0.05" material="color: green; shader:flat;"></a-tube>


### PR DESCRIPTION
This fix is in relation to issue #577 
The only change I made was changing the scale of the grid in View.js so that now when the user sets the position of an object, it lines up with the grid lines.
Example of change:
![2022-06-07 (1)](https://user-images.githubusercontent.com/90471846/172442176-21929de4-689e-4e32-8688-55aecf77fdc9.png)
