### PR TITLE
Fixed the bug with reference examples not showing up

### DIFF
--- a/src/components/layouts/ReferenceExample.js
+++ b/src/components/layouts/ReferenceExample.js
@@ -14,7 +14,7 @@ import "../../css/ReferencePage.css";
  * @param {object} param0 List of props that will be use in components
  * @returns {HTMLElement} Layout for example scene page
  */
-export const ReferenceExample = ({ editor, user, scene, referenceExample, referenceExampleActions, editorActions, authActions, projectActions, projects, courseActions, courses, match, sceneActions, collectionActions, collections }) => (
+export const ReferenceExample = ({ editor, user, scene, referenceExample, referenceExampleActions, editorActions, authActions, projectActions, projects, courseActions, courses, match, sceneActions, collectionActions, collections, userSettings, userActions }) => (
     <div className="App">
         <Header
             logging={authActions}
@@ -48,7 +48,7 @@ export const ReferenceExample = ({ editor, user, scene, referenceExample, refere
                         <div id="interface" className="col-12 col-md-4">
                             <RefExInfo referenceExample={referenceExample} />
                             <div className='ref-ex-edit'>
-                                <Editor refresh={editorActions.refresh} render={editorActions.render} text={editor.text} user={user} />
+                                <Editor refresh={editorActions.refresh} render={editorActions.render} text={editor.text} user={user} settings={userSettings} userActions={userActions} />
                             </div>
                         </div>
                         <div id="scene" className="col-12 col-md-8" >

--- a/src/containers/ReferenceExample.js
+++ b/src/containers/ReferenceExample.js
@@ -21,6 +21,7 @@ ReferenceExample.propTypes = {
 const mapStateToProps = state => ({
     editor: state.editor,
     user: state.user.user,
+    userSettings: state.user.settings,
     scene: state.scene,
     projects: state.project,
     courses: state.courses,


### PR DESCRIPTION
This is a fix to issue #583. Originally, the reference examples were not working, but now they work. All I changed was where the editor is called in rendering the example, I added the property of user settings so that the font size would work.