### PR TITLE
Improved visibility for font size and shortcuts buttons

### DIFF
--- a/src/components/editor/Editor.js
+++ b/src/components/editor/Editor.js
@@ -95,7 +95,7 @@ class Editor extends Component {
                     editorProps={{
                         $blockScrolling: Infinity,
                     }}
-                    height="90vh"
+                    height="88vh"
                     mode="javascript"
                     name="ace-editor"
                     // eslint-disable-next-line

--- a/src/components/editor/KeyboardShortcut.js
+++ b/src/components/editor/KeyboardShortcut.js
@@ -124,9 +124,11 @@ class KeyboardShortcut extends React.Component {
      */
     render(){
         return(
-            <div className="whole-keyboard">
+            <div className="whole-keyboard"
+                spacing={10}>
                 <Tooltip title="Keyboard Shortcut">
-                    <Button
+                    <Button 
+                        className="shortcut-button"
                         variant="contained"
                         size="small"
                         color="primary"

--- a/src/css/KeyboardShortcut.css
+++ b/src/css/KeyboardShortcut.css
@@ -3,11 +3,16 @@
 }
 
 .title {
-    font-size:large
+    font-size:large;
 }
 
 .shortcut {
-    font-size:xx-small
+    font-size:xx-small;
+}
+
+.shortcut-button {
+    height: 34px;
+    width: 80px;
 }
 
 .right {
@@ -21,17 +26,18 @@
 }
 
 .font-button {
-    height:33px;
-    width:70px;
+    height:34px;
+    width:80px;
 }
 
 .font {
     display: inline-block;
-    margin-left:2px;
+    margin-left: 4px;
 }
 
 .whole-keyboard {
     display: inline-block;
+    margin-left: 1px;
 }
 
 .select {


### PR DESCRIPTION
Made the code editor slightly smaller to make more space for buttons. Additionally, increased the width and height of font size and shortcuts button.

Before: 
![image](https://user-images.githubusercontent.com/53062712/175387155-eb0d48c6-75ff-4fec-aa7e-28e85111d0a7.png)

After: 
![image](https://user-images.githubusercontent.com/53062712/175387201-71cd5f3f-7fd7-493a-9659-c97d131b4b82.png)
