### PR TITLE
Fix deployment pipeline issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8256,7 +8256,7 @@
             }
         },
         "node_modules/debug": {
-            "resolved": "git+ssh://git@github.com/ngokevin/debug.git#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a"
+            "resolved": "https://github.com/ngokevin/debug.git#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a"
         },
         "node_modules/decamelize": {
             "version": "1.2.0",
@@ -8750,7 +8750,7 @@
             }
         },
         "node_modules/document-register-element": {
-            "resolved": "git+ssh://git@github.com/dmarcos/document-register-element.git#8ccc532b7f3744be954574caf3072a5fd260ca90"
+            "resolved": "https://github.com/dmarcos/document-register-element.git#8ccc532b7f3744be954574caf3072a5fd260ca90"
         },
         "node_modules/dom-converter": {
             "version": "0.2.0",
@@ -25587,7 +25587,7 @@
         },
         "node_modules/three-bmfont-text": {
             "version": "2.4.0",
-            "resolved": "git+ssh://git@github.com/dmarcos/three-bmfont-text.git#21d017046216e318362c48abd1a48bddfb6e0733",
+            "resolved": "https://github.com/dmarcos/three-bmfont-text.git#21d017046216e318362c48abd1a48bddfb6e0733",
             "integrity": "sha512-lIMa1n+QKNU1f/LZgtS1oUGpoop3MuVXrUr5ybZOUR3+Jk//zjqScnQpHml6MWyvZzL8A5/1Hd8Tsqd3M1kudA==",
             "license": "MIT",
             "dependencies": {
@@ -25602,7 +25602,7 @@
         },
         "node_modules/three-buffer-vertex-data": {
             "version": "1.1.0",
-            "resolved": "git+ssh://git@github.com/dmarcos/three-buffer-vertex-data.git#69378fc58daf27d3b1d930df9f233473e4a4818c",
+            "resolved": "https://github.com/dmarcos/three-buffer-vertex-data.git#69378fc58daf27d3b1d930df9f233473e4a4818c",
             "integrity": "sha512-ZPCCbGfueRzd2/YwH136UnVN+N11Mvxu7uPaEzIdtuk0m5HPs1LGXOM5hOkpxamjvqSC6MDJ3nd11grGi7sMKw==",
             "license": "MIT",
             "dependencies": {
@@ -34680,7 +34680,7 @@
             }
         },
         "debug": {
-            "version": "git+ssh://git@github.com/ngokevin/debug.git#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
+            "version": "https://github.com/ngokevin/debug.git#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
             "from": "debug@github:ngokevin/debug#noTimestamp"
         },
         "decamelize": {
@@ -35085,7 +35085,7 @@
             }
         },
         "document-register-element": {
-            "version": "git+ssh://git@github.com/dmarcos/document-register-element.git#8ccc532b7f3744be954574caf3072a5fd260ca90",
+            "version": "https://github.com/dmarcos/document-register-element.git#8ccc532b7f3744be954574caf3072a5fd260ca90",
             "from": "document-register-element@github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90"
         },
         "dom-converter": {
@@ -48599,7 +48599,7 @@
             "integrity": "sha512-eOEXnZeE1FDV0XgL1u08auIP13jxdN9LQBAEmlErYzMxtIIfuGIAZbijOyookALUhqVzVOx0Tywj6n192VM+nQ=="
         },
         "three-bmfont-text": {
-            "version": "git+ssh://git@github.com/dmarcos/three-bmfont-text.git#21d017046216e318362c48abd1a48bddfb6e0733",
+            "version": "https://github.com/dmarcos/three-bmfont-text.git#21d017046216e318362c48abd1a48bddfb6e0733",
             "integrity": "sha512-lIMa1n+QKNU1f/LZgtS1oUGpoop3MuVXrUr5ybZOUR3+Jk//zjqScnQpHml6MWyvZzL8A5/1Hd8Tsqd3M1kudA==",
             "from": "three-bmfont-text@github:dmarcos/three-bmfont-text#21d017046216e318362c48abd1a48bddfb6e0733",
             "requires": {
@@ -48613,7 +48613,7 @@
             }
         },
         "three-buffer-vertex-data": {
-            "version": "git+ssh://git@github.com/dmarcos/three-buffer-vertex-data.git#69378fc58daf27d3b1d930df9f233473e4a4818c",
+            "version": "https://github.com/dmarcos/three-buffer-vertex-data.git#69378fc58daf27d3b1d930df9f233473e4a4818c",
             "integrity": "sha512-ZPCCbGfueRzd2/YwH136UnVN+N11Mvxu7uPaEzIdtuk0m5HPs1LGXOM5hOkpxamjvqSC6MDJ3nd11grGi7sMKw==",
             "from": "three-buffer-vertex-data@dmarcos/three-buffer-vertex-data#69378fc58daf27d3b1d930df9f233473e4a4818c",
             "requires": {


### PR DESCRIPTION
Updated instances of SSH fetching in package-lock.json to use HTTPS instead.

# Recommended Action Items

- [ ] Figure out why SSH fetching was occurring (look at dependabot first)
- [ ] Update git to only use HTTPS fetching in the pipeline (maybe something like [this](https://stackoverflow.com/questions/61051073/npm-install-from-git-use-https-instead-ssh))
- [ ] Add a container building step in PRs