### PR TITLE
Reverted grid back to original size per Bryan's request

### DIFF
--- a/src/components/structural/View.js
+++ b/src/components/structural/View.js
@@ -354,7 +354,7 @@ class View extends Component {
         if (this.props.sceneConfig.settings.showCoordHelper) {
             return (
                 <Fragment>
-                    <a-grid height="53.33" width="53.33" position="-0.5 -0.26 -0.5" scale="1.4 1.4 1.4" material="shader:flat;" gridmaterial/>
+                    <a-grid height="53.33" width="53.33" position="-0.5 -0.26 -0.5" scale="1.5 1.5 1.5" material="shader:flat;" gridmaterial/>
                     <a-tube path="-35 -0.2 0, 35 -0.2 0" radius="0.05" material="color: red; shader:flat;"></a-tube>
                     <a-tube path="0 -0.2 -35, 0 -0.2 35" radius="0.05" material="color: blue; shader:flat;"></a-tube>
                     <a-tube path="0 -35 0, 0 35 0" radius="0.05" material="color: green; shader:flat;"></a-tube>


### PR DESCRIPTION
The grid now does not line up with objects, but it fits the floor better than the other version