### PR TITLE
Replaced depricated no-gutters with g-0

### DIFF
--- a/src/components/layouts/Ide.js
+++ b/src/components/layouts/Ide.js
@@ -41,7 +41,7 @@ export const Ide = ({ editor, editorActions, user, usersettings, userActions, au
             collections={collections}
             layoutType={layoutTypes.IDE}
         />
-        <div className="row no-gutters">
+        <div className="row g-0">
             {
                 scene.settings.viewOnly
                     ?


### PR DESCRIPTION
## Description 

This PR will fix the issue where we have horizontal overflow (meaning you could scroll horizontally) along with the issue of having a thick vertical line between the editor and the 3D space.

The issue was when we upgraded the version of bootstrap (4.6 -> 5.1). It seems the `no-gutters` bootstrap class has been deprecated and now instead is `g-0`. 

## Preview

Before:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/68972382/179786172-214688bb-e85b-4e55-b607-a31434beea04.png">
After:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/68972382/179786237-3e24176f-d52d-4952-8c0e-733a39e68d15.png">
