### PR TITLE
Expanded on replacing deprecated no-gutters

### DIFF
--- a/src/components/layouts/AssetReference.js
+++ b/src/components/layouts/AssetReference.js
@@ -30,7 +30,7 @@ export const AssetReference = ({ editor, editorActions, user, authActions, scene
             collections={collections}
             layoutType={layoutTypes.REFERENCE}
         />
-        <div className="row no-gutters">
+        <div className="row g-0">
             <AssetReferencePage />
         </div>
         <Footer />

--- a/src/components/layouts/Collection.js
+++ b/src/components/layouts/Collection.js
@@ -34,7 +34,7 @@ export const Collection = ({ editor, editorActions, user, userSettings, userActi
             collection={match.params.collection}
             layoutType={layoutTypes.COLLECTION}
         />
-        <div className="row no-gutters">
+        <div className="row g-0">
             <div id="interface" className="col-12 col-md-4">
                 <SelectProject
                     selectedCollection={match.params.collection}

--- a/src/components/layouts/Guided.js
+++ b/src/components/layouts/Guided.js
@@ -36,7 +36,7 @@ export const Guided = ({ editor, user, usersettings, userActions, scene, editorA
             collectionActions={collectionActions}
             collections={collections}
         />
-        <div className="row no-gutters">
+        <div className="row g-0">
             {
                 scene.settings.viewOnly
                     ?

--- a/src/components/layouts/Reference.js
+++ b/src/components/layouts/Reference.js
@@ -30,7 +30,7 @@ export const Reference = ({ editor, editorActions, user, authActions, scene, sce
             collections={collections}
             layoutType={layoutTypes.REFERENCE}
         />
-        <div className="row no-gutters">
+        <div className="row g-0">
             <ReferencePage />
         </div>
         <Footer />

--- a/src/components/layouts/ReferenceExample.js
+++ b/src/components/layouts/ReferenceExample.js
@@ -36,7 +36,7 @@ export const ReferenceExample = ({ editor, user, scene, referenceExample, refere
             referenceExampleActions={referenceExampleActions}
             layoutType={layoutTypes.REF_EXAMPLE}
         />
-        <div className="row no-gutters">
+        <div className="row g-0">
             {
                 scene.settings.viewOnly
                     ?

--- a/src/components/structural/WelcomeScreen.js
+++ b/src/components/structural/WelcomeScreen.js
@@ -322,7 +322,7 @@ class Welcome extends React.Component {
                                 <this.cookieMessage />
                             </Hidden>
                             <hr />
-                            <div className="row no-gutters">
+                            <div className="row g-0">
                                 <div id="welcome-description" className="col-12 col-md-6 col-lg-8">
                                     <p>MYR is an educational tool that strikes a balance with the ease of use and challenge. We drew inspiration from Logo Turtle and Processing to provide a beginner friendly experience for teaching and learning with MYR. If you want to learn more about MYR itself, visit our <a href="/about" target="_blank" rel="noopener noreferrer">about page</a>.</p>
                                     <p>Within the editor you can create 3D scenes using JavaScript and the MYR API. You can then view your scene in the viewer using a computer, tablet, smartphone, or a VR headset.</p>


### PR DESCRIPTION
## Description
<!-- Explain what your pull request does and its what it resolves -->
This PR is similar to Bryan's recent PR #608, as he was replacing the deprecated no-gutters with g-0, and I just did that in all the places that no-gutters is found. This is because I realized that the examples pages still had the larger middle bar, so every instance of no-gutters had to be changed.


