### PR TITLE
Scene title and description editing

### DIFF
--- a/src/components/structural/WelcomeScreen.js
+++ b/src/components/structural/WelcomeScreen.js
@@ -277,7 +277,7 @@ class Welcome extends React.Component {
                     handleProjectToggle={this.handleProjectToggle}
                     tab={this.state.projectsTab}
                     hideTooltip={true}
-                    saveDrawer={this.props.saveDrawer} />
+                    renameScene={this.props.renameScene} />
                 <CourseSelect
                     courses={this.props.courses}
                     coursesOpen={this.state.coursesOpen}

--- a/src/components/structural/WelcomeScreen.js
+++ b/src/components/structural/WelcomeScreen.js
@@ -276,7 +276,8 @@ class Welcome extends React.Component {
                     projectsOpen={this.state.projectsOpen}
                     handleProjectToggle={this.handleProjectToggle}
                     tab={this.state.projectsTab}
-                    hideTooltip={true} />
+                    hideTooltip={true}
+                    saveDrawer={this.props.saveDrawer} />
                 <CourseSelect
                     courses={this.props.courses}
                     coursesOpen={this.state.coursesOpen}

--- a/src/components/structural/header/Header.js
+++ b/src/components/structural/header/Header.js
@@ -758,7 +758,8 @@ class Header extends Component {
                             userProjs={this.props.projects.userProjs}
                             exampleProjs={this.props.projects.exampleProjs}
                             courses={this.props.courses.courses}
-                            handleTourToggle={this.handleTourToggle} />
+                            handleTourToggle={this.handleTourToggle}
+                            saveDrawer={this.saveDrawer} />
                         <Tooltip title="Stop" placement="bottom-start">
                             <Button
                                 id="stop-btn"
@@ -799,7 +800,8 @@ class Header extends Component {
                         projectsOpen={this.state.projectsOpen}
                         handleProjectToggle={this.handleProjectToggle}
                         tab={this.state.projectTab}
-                        user={this.props.user} />
+                        user={this.props.user}
+                        saveDrawer={this.saveDrawer} />
                     <MyrTour
                         tourOpen={this.state.tourOpen}
                         handleTourToggle={this.handleTourToggle}

--- a/src/components/structural/header/Header.js
+++ b/src/components/structural/header/Header.js
@@ -489,6 +489,11 @@ class Header extends Component {
      */
     handleSaveOpen = () => this.setState({ saveOpen: true });
 
+    renameScene = () => {
+        this.setState({ needsNewId: true });
+        this.handleSaveOpen();
+    }
+
     /**
      * creates the save drawer
      */
@@ -759,7 +764,7 @@ class Header extends Component {
                             exampleProjs={this.props.projects.exampleProjs}
                             courses={this.props.courses.courses}
                             handleTourToggle={this.handleTourToggle}
-                            saveDrawer={this.saveDrawer} />
+                            renameScene={this.renameScene} />
                         <Tooltip title="Stop" placement="bottom-start">
                             <Button
                                 id="stop-btn"
@@ -801,7 +806,7 @@ class Header extends Component {
                         handleProjectToggle={this.handleProjectToggle}
                         tab={this.state.projectTab}
                         user={this.props.user}
-                        saveDrawer={this.saveDrawer} />
+                        renameScene={this.renameScene} />
                     <MyrTour
                         tourOpen={this.state.tourOpen}
                         handleTourToggle={this.handleTourToggle}

--- a/src/components/structural/header/ProjectView.js
+++ b/src/components/structural/header/ProjectView.js
@@ -265,6 +265,9 @@ class Project extends React.Component {
         );
     };
 
+    /**
+     * Allows user to change the title and description for a scene they gave saved
+     */
     redoScene = () => {
         this.props.renameScene();
         this.props.handleProjectToggle();

--- a/src/components/structural/header/ProjectView.js
+++ b/src/components/structural/header/ProjectView.js
@@ -268,9 +268,16 @@ class Project extends React.Component {
     /**
      * Allows user to change the title and description for a scene they gave saved
      */
-    redoScene = () => {
-        this.props.renameScene();
-        this.props.handleProjectToggle();
+    redoScene = (id) => {
+        if(window.location.href !== `${window.origin}/scene/${id}` && window.location.href !== `${window.origin}/scene/${id}/`)
+        {
+            alert("You must have the project open in order to edit it!");
+        }
+        else
+        {
+            this.props.renameScene();
+            this.props.handleProjectToggle();
+        }
     }
     
     /**
@@ -321,7 +328,7 @@ class Project extends React.Component {
                                 id={id}
                                 title="Edit"
                                 color="primary"
-                                onClick={this.redoScene}>
+                                onClick={() => this.redoScene(id)}>
                                 <Icon className="material-icons">edit</Icon>
                             </IconButton>
                         </span>

--- a/src/components/structural/header/ProjectView.js
+++ b/src/components/structural/header/ProjectView.js
@@ -287,6 +287,7 @@ class Project extends React.Component {
                         <span className="scene-btns">
                             <IconButton
                                 id={id}
+                                title="Info"
                                 color="primary"
                                 onClick={this.handleInfoUserClick}
                                 className="" >
@@ -294,6 +295,7 @@ class Project extends React.Component {
                             </IconButton>
                             <IconButton
                                 id={id}
+                                title="Share"
                                 color="primary"
                                 onClick={this.handleClick}
                                 className="" >
@@ -301,15 +303,24 @@ class Project extends React.Component {
                             </IconButton>
                             <IconButton
                                 label="delete Project"
+                                title="Delete Project"
                                 color="secondary"
                                 fullwidth={String(!this.state.showImg)}
                                 onClick={() => this.props.deleteFunc(this.props.user.uid, id, proj.name)}>
                                 <Icon className="material-icons">delete</Icon>
                             </IconButton>
+                            <IconButton
+                                id={id}
+                                title="Edit"
+                                color="primary"
+                                onClick={this.props.saveDrawer}>
+                                <Icon className="material-icons">edit</Icon>
+                            </IconButton>
                         </span>
                         : <span className="scene-btns">
                             <IconButton
                                 id={id}
+                                title="Info"
                                 color="primary"
                                 onClick={this.handleInfoExampleClick}
                                 className="" >
@@ -317,6 +328,7 @@ class Project extends React.Component {
                             </IconButton>
                             <IconButton
                                 id={id}
+                                title="Share"
                                 color="primary"
                                 onClick={this.handleClick}
                                 className="" >

--- a/src/components/structural/header/ProjectView.js
+++ b/src/components/structural/header/ProjectView.js
@@ -264,6 +264,11 @@ class Project extends React.Component {
             </div>
         );
     };
+
+    redoScene = () => {
+        this.props.renameScene();
+        this.props.handleProjectToggle();
+    }
     
     /**
      * Helper for creating the project card
@@ -313,7 +318,7 @@ class Project extends React.Component {
                                 id={id}
                                 title="Edit"
                                 color="primary"
-                                onClick={this.props.saveDrawer}>
+                                onClick={this.redoScene}>
                                 <Icon className="material-icons">edit</Icon>
                             </IconButton>
                         </span>


### PR DESCRIPTION
## Description
<!-- Explain what your pull request does and its what it resolves -->
This pull request is for a new feature: being able to edit the title and description of a scene that has already been saved. I added a new button in the open projects folder that when clicked, pulls up the option to change the title and description of the scene. However, the project must be open for this to work, so if the project is not open and the user presses the button, an error message pops up telling them to open the project first.

I can do a demo of this feature in the next meeting, as pictures are not great for explaining how it works.
## Preview
<!-- Submit a screenshot of your changes down below (If not applicable then there's no need) -->
Preview of the button:
![2022-07-19](https://user-images.githubusercontent.com/90471846/179826494-bfcc291d-380e-41f3-98c1-9c32e9730c69.png)

Preview of the error message:
![2022-07-19 (1)](https://user-images.githubusercontent.com/90471846/179826537-eddaa7f6-0aef-4706-ade7-ea3527b90fa1.png)

