### PR TITLE
Fix for scaling in groups

### DIFF
--- a/src/myr/Myr.js
+++ b/src/myr/Myr.js
@@ -2031,6 +2031,7 @@ class Myr {
      * Return a Entity that can be used to group elements together
      */
     group = () => {
+        this.resetCursor();
         let base = {
             id: "grp" + this.genNewId(),
             position: { ...this.cursor.position },


### PR DESCRIPTION
## Description
This fixes the issue where a previous setScale would influence a group that was created. If a setScale was called, then a group, then another setScale, the group would use the first setScale. Now, I have the group function call the resetCursor function so that it automatically resets the cursor and you won't have this bad interaction anymore.
## Preview
Before the fix:
![2022-08-04 (1)](https://user-images.githubusercontent.com/90471846/182925191-a246d04c-e0e7-46fe-a6e0-fe1f2b152dac.png)
After the fix:
![2022-08-04](https://user-images.githubusercontent.com/90471846/182925243-1d4e2f45-fb38-40f7-8bbd-2321ac3a4775.png)


## Related Issue
#614 
