### PR TITLE
Added new hover effect to project view

### DIFF
--- a/src/components/structural/Footer.js
+++ b/src/components/structural/Footer.js
@@ -12,36 +12,36 @@ class Footer extends Component {
                         <span><strong>MYR:</strong></span>
                         <ul className="pl-2 list-inline">
                             <li className="pl-2 list-inline-item">
-                                <a href="https://learnmyr.org/about/" target="_blank" rel="noopener noreferrer">About</a>
+                                <a href="https://learnmyr.org/about/" target="_blank" rel="noopener noreferrer" className = "text-decoration-none">About</a>
                             </li>
                             <li className="pl-2 list-inline-item">
-                                <a href="mailto:support@learnmyr.org" target="_blank" rel="noopener noreferrer">Support</a>
+                                <a href="mailto:support@learnmyr.org" target="_blank" rel="noopener noreferrer" className = "text-decoration-none">Support</a>
                             </li>
                             <li className="pl-2 list-inline-item">
-                                <a href="https://learnmyr.org/about/team/" target="_blank" rel="noopener noreferrer">Team </a>
+                                <a href="https://learnmyr.org/about/team/" target="_blank" rel="noopener noreferrer" className = "text-decoration-none">Team </a>
                             </li>
                             <li className="pl-2 list-inline-item">
-                                <a href="https://github.com/engaging-computing/MYR" target="_blank" rel="noopener noreferrer">GitHub</a>
+                                <a href="https://github.com/engaging-computing/MYR" target="_blank" rel="noopener noreferrer" className = "text-decoration-none">GitHub</a>
                             </li>
                         </ul>
                     </div>
                     <div className="col-lg-4 d-none d-md-block text-center">
                         <div>© 2018 - {new Date().getFullYear()}<span>&nbsp;</span>
-                            <a href="https://sites.uml.edu/engaging-computing/" target="_blank" rel="noopener noreferrer">University of Massachusetts Lowell, Engaging Computing Group</a>
+                            <a href="https://sites.uml.edu/engaging-computing/" target="_blank" rel="noopener noreferrer" className = "text-decoration-none">University of Massachusetts Lowell, Engaging Computing Group</a>
                         </div>
                     </div>
                     <div className="col-sm-12 d-block d-md-none text-center">
                         <div>© 2018 - {new Date().getFullYear()}<br />
-                            <a href="https://sites.uml.edu/engaging-computing/" target="_blank" rel="noopener noreferrer">University of Massachusetts Lowell,<br />Engaging Computing Group</a>
+                            <a href="https://sites.uml.edu/engaging-computing/" target="_blank" rel="noopener noreferrer" className = "text-decoration-none">University of Massachusetts Lowell,<br />Engaging Computing Group</a>
                         </div>
                     </div>
                     <div className="col-lg-4">
                         <ul className=" list-inline text-lg-right">
                             <li className="pl-2 list-inline-item">
-                                <a href="https://learnmyr.org/about/privacy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+                                <a href="https://learnmyr.org/about/privacy/" target="_blank" rel="noopener noreferrer" className = "text-decoration-none">Privacy Policy</a>
                             </li>
                             <li className="pl-2 list-inline-item">
-                                <a href="https://learnmyr.org/about/tos/" target="_blank" rel="noopener noreferrer">Terms of Service</a>
+                                <a href="https://learnmyr.org/about/tos/" target="_blank" rel="noopener noreferrer" className = "text-decoration-none">Terms of Service</a>
                             </li>
                         </ul>
                     </div>

--- a/src/components/structural/header/ProjectView.js
+++ b/src/components/structural/header/ProjectView.js
@@ -276,9 +276,9 @@ class Project extends React.Component {
             let id = proj._id;
             let name = proj.name;
             return (
-                <div key={id} id={id} title={name}
+                <div key={id} id="scene-card" title={name}
                     className="proj col-xs-12 col-md-6 col-lg-4 pt-2 pl-0" >
-                    <a href={`/scene/${id}`} >
+                    <a href={`/scene/${id}`} className = "text-decoration-none">
                         <span className="project-span">{name}</span>
                         <img id={id} alt={id} src={proj.url}
                             className={"img-thumbnail " + (this.state.showImg && "d-none")} />

--- a/src/css/ProjectView.css
+++ b/src/css/ProjectView.css
@@ -9,3 +9,7 @@ p#info-description {
     justify-content: space-around;
     overflow: auto !important;
 }
+
+#scene-card:hover {
+    background-color: rgb(206, 206, 192);
+}


### PR DESCRIPTION
## Description
This pull request adds a new hover effect to the project view. Before, when a user hovered their mouse above a scene in project view, it would just underline the name of the scene. Now, when you hover above a scene, it no longer underlines the name, but instead makes the background of the entire scene card grey, to emphasize that you are opening that scene. 

Also, while making these changes, I found how to remove the underlines for all the links in the footer, which was another issue in dev, so now all that needs to be fixed in the footer is the spacing.

As for the hover effect, there are more things I can do with it, such as making the card slightly bigger, but for now, I am submitting the most simple effect, and we can discuss what other animations we might want for the hover effect.
## Preview
![2022-08-04 (2)](https://user-images.githubusercontent.com/90471846/182938293-3950126f-c044-41c6-9bf9-cc854f498ed1.png)


## Related Issue
#613 
