### PR TITLE
Items in the footer are aligned better than before

### DIFF
--- a/src/components/structural/Footer.js
+++ b/src/components/structural/Footer.js
@@ -10,7 +10,7 @@ class Footer extends Component {
                 <div className="row m-3 text-center" >
                     <div className="col-lg-4 d-flex">
                         <span><strong>MYR:</strong></span>
-                        <ul className="pl-2 list-inline">
+                        <ul className="pl-2">
                             <li className="pl-2 list-inline-item">
                                 <a href="https://learnmyr.org/about/" target="_blank" rel="noopener noreferrer">About</a>
                             </li>


### PR DESCRIPTION
## Description
This PR fixes the issue with the items in the footer not being aligned properly. I simply removed the 'list-inline' property in the Footer.js file, and the items are more spread out.

This fix does not look exactly like it did before, but it does spread the items out a bit and looks better than what we currently have in dev.
## Preview
![2022-08-04 (3)](https://user-images.githubusercontent.com/90471846/182948277-37d334e0-a61f-4801-8900-44ee99deee3e.png)


## Related Issue
#611 
