### PR TITLE
Updated the Speed Slider UI to make more user-friendly

### DIFF
--- a/src/components/structural/header/SceneConfigMenu.js
+++ b/src/components/structural/header/SceneConfigMenu.js
@@ -678,16 +678,19 @@ class ConfigModal extends Component {
                                                 ?
                                                 <div id="speed-config" className="col-12 pt-4">
                                                     <div className="row">
-                                                        <div className="col-9">
+                                                        <div className="col-9 d-inline-flex">
+                                                            <label className="px-3">Slow</label>
                                                             <Slider
+                                                                className="align-self-top"
                                                                 value={this.state.moveSpeed}
-                                                                valueLabelDisplay="auto" 
                                                                 onChange={this.handleMoveSpeedUpdate}
                                                                 onChangeCommitted={this.handleMoveSpeedUpdate}
-                                                                min={0}
+                                                                min={150}
                                                                 max={1000} />
+                                                            <label className="px-3">Fast</label>
+
                                                         </div>
-                                                        <div className="col-3 align-top">
+                                                        <div className="col-3 align-top d-inline-flex">
                                                             <ButtonBase
                                                                 onClick={() => this.handleMoveSpeedUpdate(null, 150)}>
                                                                 <Icon className="material-icons">settings_backup_restore</Icon>


### PR DESCRIPTION
## Description
On the production of MYR, the speed slider has the value of speed when you hover over it. It started at 0, which seems like it would prevent the user from moving but instead the user could still move, just at the lowest speed. This pull request makes the speed slider in scene settings make more sense to the user. To do this, the arbitrary units of speed (which previously showed the user 0-1000) have been taken away and instead replacing them with words that show that moving the slider to the left makes the user slower and moving it to the right goes faster. 

## Preview
Before (Production version of MYR):
![image](https://user-images.githubusercontent.com/53062712/182951021-90417284-3377-47d5-8722-271ccc673cd8.png)

After: 
![image](https://user-images.githubusercontent.com/53062712/182951291-925ed2a3-27ad-45ec-997a-f3a46ce364c2.png)

## Related Issue
Issue #601 
