### PR TITLE
Updated `shrink()` and `grow()` documentation to reference magnitude function

### DIFF
--- a/src/myr/reference.js
+++ b/src/myr/reference.js
@@ -625,13 +625,13 @@ const animations = [
     {
         name: "grow",
         parameters: [{ type: "string", name: "elementID" }],
-        description: <span>The grow function scales the element by a [magnitude] multiplier in the x, y, z components.</span>,
+        description: <span>The grow function scales the element by a [magnitude] multiplier in the x, y, z components. Use the setMagnitude function before passing the grow function.</span>,
         example: "grow"
     },
     {
         name: "shrink",
         parameters: [{ type: "string", name: "elementID" }],
-        description: <span>The shrink function scales the element down by the inverse of the magnitude in the x, y, z components.</span>,
+        description: <span>The shrink function scales the element down by the inverse of the magnitude in the x, y, z components. Use the setMagnitude function before passing the shrink function and set the magnitude to any value other than 1 to see the animation.</span>,
         example: "shrink"
     },
     {


### PR DESCRIPTION
## Description
When looking at the reference page, some of the animation functions seem unusable without the use of other functions like `setMagnitude()`.The purpose of this PR is to make the `shrink()` and `grow()` functions easier to understand for any new user by referencing `setMagnitude()` in the description. Otherwise, the only way a user would know to use `setMagnitude()` would be to click the examples page. 

## Preview
Before: 
![image](https://user-images.githubusercontent.com/53062712/183726543-8c9cb6b0-cb4d-4615-bcf1-9fb0b82e646b.png)
After:
![image](https://user-images.githubusercontent.com/53062712/183726946-c2a48939-c268-4a26-8f73-4805cbfa50d3.png)

## Related Issue
Issue #517 