### PR TITLE
Flat-based objects positioned correctly

### DIFF
--- a/src/myr/Myr.js
+++ b/src/myr/Myr.js
@@ -280,11 +280,10 @@ class Myr {
      */
     setPosition = (x = 0, y = 1, z = 0) => {
         if (typeof x === "number" && typeof y === "number" && typeof z === "number") {
-            this.cursor.position = {
-                x: x,
-                y: y,
-                z: z
-            };
+            let trueY = ((this.cursor.scale.y / 2) - 0.5) + y;
+            this.cursor.position.x = x;
+            this.cursor.position.y = trueY;
+            this.cursor.position.z = z;
         } else {
             console.error("setPosition() must be all numeric values");
         }
@@ -311,8 +310,9 @@ class Myr {
      * @param {number} y New y position of the cursor
      */
     setYPos = (y = 0) => {
+        let trueY = ((this.cursor.scale.y / 2) - 0.5) + y;
         if (typeof y === "number") {
-            this.cursor.position = { ...this.cursor.position, y };
+            this.cursor.position.y = trueY;
         } else {
             console.error("must pass a numeric for setYPos");
         }


### PR DESCRIPTION
## Description
These changes (to `setPosition()` and `setYPos()`) make it so that objects with flat bases (`box()`, `cylinder()`, etc.) are positioned correctly on the floor when y is set to 0. This was a problem caused by scaling, since the position is set based on the center of the object, which does not change when the scale is changed. So, that is why there were issues with objects being set at y=0, yet not actually being aligned on the ground.
As of now, this fix only works for objects with flat bases, but it seems to be an improvement on the current functions in production.
## Preview
![2022-08-11 (1)](https://user-images.githubusercontent.com/90471846/184234576-27396b85-2f8c-42dc-acb3-c146f08c921d.png)


## Related Issue
#604 
