### PR TITLE
Update spin function

### DIFF
--- a/src/myr/Myr.js
+++ b/src/myr/Myr.js
@@ -1410,6 +1410,85 @@ class Myr {
         return outerElId;
     };
 
+
+    /**
+     * Apply a spin animation on the X axis to the Aframe element which is passed as arg
+     * 
+     * @param {number} outerElId target element ID
+     * @param {number} magnitude Magnitude of the animation
+     * @param {boolean} loop     Whether to loop the animation
+     * @param {number} duration  How long the animation last
+     * @param {string} spinType Direction of the animation
+     */
+    spinX = (outerElId, spinType, magnitude = null, loop = null, duration = null) => {
+        magnitude = magnitude !== null ? magnitude : this.cursor.magnitude.spin;
+        loop = loop !== null ? loop : this.cursor.loop;
+        duration = duration !== null ? duration : this.cursor.duration;
+        let el = this.getEl(outerElId);
+        let anim = `
+      property: rotation;
+      dir: ${spinType};
+      dur: ${duration};
+      loop: ${Boolean(loop)};
+      easing: linear;
+      to: ${el.rotation.x + magnitude} ${el.rotation.y} ${el.rotation.z};
+    `;
+        el.animation__spin = anim;
+        return outerElId;
+    };
+
+    /**
+     * Apply a spin animation on the X axis to the Aframe element which is passed as arg
+     * 
+     * @param {number} outerElId target element ID
+     * @param {number} magnitude Magnitude of the animation
+     * @param {boolean} loop     Whether to loop the animation
+     * @param {number} duration  How long the animation last
+     * @param {string} spinType Direction of the animation
+     */
+    spinY = (outerElId, spinType, magnitude = null, loop = null, duration = null) => {
+        magnitude = magnitude !== null ? magnitude : this.cursor.magnitude.spin;
+        loop = loop !== null ? loop : this.cursor.loop;
+        duration = duration !== null ? duration : this.cursor.duration;
+        let el = this.getEl(outerElId);
+        let anim = `
+      property: rotation;
+      dir: ${spinType};
+      dur: ${duration};
+      loop: ${Boolean(loop)};
+      easing: linear;
+      to: ${el.rotation.x} ${el.rotation.y + magnitude} ${el.rotation.z};
+    `;
+        el.animation__spin = anim;
+        return outerElId;
+    };
+
+    /**
+     * Apply a spin animation on the Z axis to the Aframe element which is passed as arg
+     * 
+     * @param {number} outerElId target element ID
+     * @param {number} magnitude Magnitude of the animation
+     * @param {boolean} loop     Whether to loop the animation
+     * @param {number} duration  How long the animation last
+     * @param {string} spinType Direction of the animation
+     */
+    spinZ = (outerElId, spinType, magnitude = null, loop = null, duration = null) => {
+        magnitude = magnitude !== null ? magnitude : this.cursor.magnitude.spin;
+        loop = loop !== null ? loop : this.cursor.loop;
+        duration = duration !== null ? duration : this.cursor.duration;
+        let el = this.getEl(outerElId);
+        let anim = `
+      property: rotation;
+      dir: ${spinType};
+      dur: ${duration};
+      loop: ${Boolean(loop)};
+      easing: linear;
+      to: ${el.rotation.x} ${el.rotation.y} ${el.rotation.z + magnitude};
+    `;
+        el.animation__spin = anim;
+        return outerElId;
+    };
+
     /**
      * Apply a yoyo animation to the Aframe element which is passed as arg
      * 

--- a/src/myr/reference.js
+++ b/src/myr/reference.js
@@ -575,6 +575,21 @@ const animations = [
         example: "spin"
     },
     {
+        name: "spinX",
+        parameters: [{ type: "string", name: "elementID"}, {type: "string", name: "spinType"}],
+        description: <span>The spin function spins the given element around the x axis in degrees. The second parameter specifies the type of the spin, which include "normal," "alternate," and "reverse." This spin type is optional, so if it is not specified, the object will spin using the "normal" spin type.</span>,
+    },
+    {
+        name: "spinY",
+        parameters: [{ type: "string", name: "elementID" }, {type: "string", name: "spinType"}],
+        description: <span>The spin function spins the given element around the y axis in degrees. The second parameter specifies the type of the spin, which include "normal," "alternate," and "reverse." This spin type is optional, so if it is not specified, the object will spin using the "normal" spin type.</span>,
+    },
+    {
+        name: "spinZ",
+        parameters: [{ type: "string", name: "elementID" }, {type: "string", name: "spinType"}],
+        description: <span>The spin function spins the given element around the Z axis in degrees. The second parameter specifies the type of the spin, which include "normal," "alternate," and "reverse." This spin type is optional, so if it is not specified, the object will spin using the "normal" spin type.</span>,
+    },
+    {
         name: "yoyo",
         parameters: [{ type: "string", name: "elementID" }],
         description: <span>The yoyo function bounces the given element a number of units.</span>,


### PR DESCRIPTION
## Description
I created three new spin functions called spinX, spinY, and spinZ. These functions allow for greater modularity than the original spin function because now users have the option of spinning across all axes as opposed to just one axis. Additionally, these functions have a second optional parameter that specifies the spin type of the given object. These include "normal," which spins the object counterclockwise, "reverse," which spins the object clockwise, and "alternate," which spins the object both ways after a certain duration. 

The previous spin function has not yet been removed because it may cause issues in courses and example scenes. 

## Preview
New functions in the reference page: 
![image](https://user-images.githubusercontent.com/53062712/184943923-0d0f41c2-7321-405a-b9da-c994134d8a9c.png)

## Related Issue
Issue #502 