### PR TITLE
Fixed dev camera speed issues

### DIFF
--- a/src/components/structural/View.js
+++ b/src/components/structural/View.js
@@ -292,6 +292,7 @@ class View extends Component {
      * @returns {HTMLElement} A-Frame camera elements with basic movement
      */
     basicMoveCam = () => {
+        let realSpeed = (this.props.sceneConfig.settings.moveSpeed / 10) + 10;
         switch(browserType()) {
             case "mobile":
                 return (
@@ -331,7 +332,7 @@ class View extends Component {
                         <a-camera
                             position={this.props.sceneConfig.settings.cameraPosition}
                             look-controls="pointerLockEnabled: true"
-                            wasd-plus-controls={`acceleration: ${this.props.sceneConfig.settings.moveSpeed}`}>
+                            wasd-controls={`acceleration: ${realSpeed}`}>
                             <a-cursor
                                 raycaster="objects:.raycastable"
                                 position="0 0 -1"


### PR DESCRIPTION
## Description
Currently on dev, the camera speed is way too fast, most likely due to updating the a-frame version. However, despite looking through the a-frame docs and version changes, I was unable to find anything that would affect this. Ultimately, this PR simply adds a new variable that scales down the speed input from the slider, which seems to do the trick. The speeds closely line up with those in production.
## Preview
A screenshot is not applicable here, but I can do a demo if needed.

## Related Issue
#600 
