### PR TITLE
Fixed the function call for displayCursor

### DIFF
--- a/src/components/structural/View.js
+++ b/src/components/structural/View.js
@@ -322,7 +322,7 @@ class View extends Component {
                                 raycaster="objects:.raycastable"
                                 position="0 0 -1"
                                 geometry="primitive: ring; radiusInner: 0.02; radiusOuter: 0.03;"
-                                material={this.displayCursor} />
+                                material={this.displayCursor()} />
                         </a-camera>
                     </a-entity> 
                 );
@@ -337,7 +337,7 @@ class View extends Component {
                                 raycaster="objects:.raycastable"
                                 position="0 0 -1"
                                 geometry="primitive: ring; radiusInner: 0.02; radiusOuter: 0.03;"
-                                material={this.displayCursor} />
+                                material={this.displayCursor()} />
                         </a-camera>
                     </a-entity> 
                 );


### PR DESCRIPTION
## Description
Have not been able to test this for mobile, but I believe this could be causing the problem with VR mode not working on mobile devices. Plus, this won't break anything, because I've just added parentheses to a function call.

