### PR TITLE
Downgrade AFrame 1.3 -> 1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@engaging-computing/aframe-physics-system": "^4.0.0",
                 "@material-ui/core": "^4.12.3",
-                "aframe": "^1.3.0",
+                "aframe": "1.2",
                 "aframe-animation-component": "^5.0.0",
                 "aframe-environment-component": "^1.3.1",
                 "aframe-extras": "^4.1.2",
@@ -4619,9 +4619,9 @@
             }
         },
         "node_modules/aframe": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/aframe/-/aframe-1.3.0.tgz",
-            "integrity": "sha512-f6OQaDf49SzdSxVskJPvPWldOwHpYMsGttmQHhU6FRiASsnyULKG1nqZom9pDuS3fFYEzQVqRMakQ2AhXeLkFg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aframe/-/aframe-1.2.0.tgz",
+            "integrity": "sha512-e4lGvxLQ5CAptlbCqmnR4+qUf9s3f5SSnkMQaBsIFlJ2QMZhzEBr/SSV3+NEvMhsQf88EOvSpN1Vez942mBLcQ==",
             "dependencies": {
                 "custom-event-polyfill": "^1.0.6",
                 "debug": "github:ngokevin/debug#noTimestamp",
@@ -4632,13 +4632,13 @@
                 "present": "0.0.6",
                 "promise-polyfill": "^3.1.0",
                 "super-animejs": "^3.1.0",
-                "super-three": "^0.137.0",
-                "three-bmfont-text": "github:dmarcos/three-bmfont-text#21d017046216e318362c48abd1a48bddfb6e0733",
+                "super-three": "^0.125.1",
+                "three-bmfont-text": "github:dmarcos/three-bmfont-text#1babdf8507c731a18f8af3b807292e2b9740955e",
                 "webvr-polyfill": "^0.10.12"
             },
             "engines": {
                 "node": ">= 4.6.0",
-                "npm": ">= 2.15.9"
+                "npm": "^2.15.9"
             }
         },
         "node_modules/aframe-animation-component": {
@@ -4777,7 +4777,7 @@
         "node_modules/an-array": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/an-array/-/an-array-1.0.0.tgz",
-            "integrity": "sha1-wSWlu4JXd4419LT2qpx9D6nkJmU="
+            "integrity": "sha512-M175GYI7RmsYu24Ok383yZQa3eveDfNnmhTe3OQ3bm70bEovz2gWenH+ST/n32M8lrwLWk74hcPds5CDRPe2wg=="
         },
         "node_modules/animejs": {
             "version": "2.2.0",
@@ -4959,7 +4959,7 @@
         "node_modules/array-shuffle": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/array-shuffle/-/array-shuffle-1.0.1.tgz",
-            "integrity": "sha1-fqSIKjVrS8pfVF4LblLq9tlxVXo=",
+            "integrity": "sha512-PBqgo1Y2XWSksBzq3GFPEb798ZrW2snAcmr4drbVeF/6MT/5aBlkGJEvu5A/CzXHf4EjbHOj/ZowatjlIiVidA==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5052,7 +5052,7 @@
         "node_modules/as-number": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/as-number/-/as-number-1.0.0.tgz",
-            "integrity": "sha1-rLJ+NPj52KsNqeN287iVmGD4CmY="
+            "integrity": "sha512-HkI/zLo2AbSRO4fqVkmyf3hms0bJDs3iboHqTrNuwTiCRvdYXM7HFhfhB6Dk51anV2LM/IMB83mtK9mHw4FlAg=="
         },
         "node_modules/asap": {
             "version": "2.0.6",
@@ -6554,7 +6554,7 @@
         "node_modules/buffer-to-arraybuffer": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
-            "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
+            "integrity": "sha512-3dthu5CYiVB1DEJp61FtApNnNndTckcqe4pFcLdvHtrpG+kcyekCJKg4MRiDcFW7A6AODnXB9U4dwQiCW5kzJQ=="
         },
         "node_modules/buffer-xor": {
             "version": "1.0.3",
@@ -8277,7 +8277,7 @@
             }
         },
         "node_modules/debug": {
-            "resolved": "https://github.com/ngokevin/debug.git#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a"
+            "resolved": "git+ssh://git@github.com/ngokevin/debug.git#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a"
         },
         "node_modules/decamelize": {
             "version": "1.2.0",
@@ -8304,7 +8304,7 @@
         "node_modules/decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
             "dependencies": {
                 "mimic-response": "^1.0.0"
             },
@@ -8771,7 +8771,7 @@
             }
         },
         "node_modules/document-register-element": {
-            "resolved": "https://github.com/dmarcos/document-register-element.git#8ccc532b7f3744be954574caf3072a5fd260ca90"
+            "resolved": "git+ssh://git@github.com/dmarcos/document-register-element.git#8ccc532b7f3744be954574caf3072a5fd260ca90"
         },
         "node_modules/dom-converter": {
             "version": "0.2.0",
@@ -8918,7 +8918,7 @@
         "node_modules/dtype": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
-            "integrity": "sha1-zQUjI84GFETs0uj1dI9popvihDQ=",
+            "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg==",
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -17139,7 +17139,7 @@
         "node_modules/layout-bmfont-text": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/layout-bmfont-text/-/layout-bmfont-text-1.3.4.tgz",
-            "integrity": "sha1-8g8sVGR3T0jabOipl/vObUaUW4E=",
+            "integrity": "sha512-mceomHZ8W7pSKQhTdLvOe1Im4n37u8xa5Gr0J3KPCHRMO/9o7+goWIOzZcUUd+Xgzy3+22bvoIQ0OaN3LRtgaw==",
             "dependencies": {
                 "as-number": "^1.0.0",
                 "word-wrapper": "^1.0.7",
@@ -17541,7 +17541,7 @@
         "node_modules/map-limit": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
-            "integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
+            "integrity": "sha512-pJpcfLPnIF/Sk3taPW21G/RQsEEirGaFpCW3oXRwH9dnFHPHNGjNyvh++rdmC2fNqEaTw2MhYJraoJWAHx8kEg==",
             "dependencies": {
                 "once": "~1.3.0"
             }
@@ -17549,7 +17549,7 @@
         "node_modules/map-limit/node_modules/once": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+            "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
             "dependencies": {
                 "wrappy": "1"
             }
@@ -18127,7 +18127,7 @@
         "node_modules/new-array": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/new-array/-/new-array-1.0.0.tgz",
-            "integrity": "sha1-XbxjnZYerH8an7wacUbsEvKST78="
+            "integrity": "sha512-K5AyFYbuHZ4e/ti52y7k18q8UHsS78FlRd85w2Fmsd6AkuLipDihPflKC0p3PN5i8II7+uHxo+CtkLiJDfmS5A=="
         },
         "node_modules/next-tick": {
             "version": "1.0.0",
@@ -18138,7 +18138,7 @@
         "node_modules/nice-color-palettes": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/nice-color-palettes/-/nice-color-palettes-1.0.1.tgz",
-            "integrity": "sha1-h16gHchu+uf1leBmqLJmDnIGBT4=",
+            "integrity": "sha512-aHEFYKuGiaga8LqMi0Ttarqzn4tKS7BaIE2MeD9SDjv6yVc7DMIu/Eax4RvUgwR7vS0hXAUEIUx9P0/54O1W0g==",
             "dependencies": {
                 "map-limit": "0.0.1",
                 "minimist": "^1.2.0",
@@ -21039,7 +21039,7 @@
         "node_modules/quad-indices": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/quad-indices/-/quad-indices-2.0.1.tgz",
-            "integrity": "sha1-ppQdiaE9Y+7WwdSlpiGgRjYXqBQ=",
+            "integrity": "sha512-6jtmCsEbGAh5npThXrBaubbTjPcF0rMbn57XCJVI7LkW8PUT56V+uIrRCCWCn85PSgJC9v8Pm5tnJDwmOBewvA==",
             "dependencies": {
                 "an-array": "^1.0.0",
                 "dtype": "^2.0.0",
@@ -25010,9 +25010,9 @@
             "integrity": "sha512-6MFAFJDRuvwkovxQZPruuyHinTa4rgj4hNLOndjcYYhZLckoXtVRY9rJPuq8p6c/tgZJrFYEAYAfJ2/hhNtUCA=="
         },
         "node_modules/super-three": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/super-three/-/super-three-0.137.0.tgz",
-            "integrity": "sha512-8jM8DiYiXQoalUoeFRxKWbW6KFQo3GFwgw+3vE2y6SJU/einw+JvuvgK+WhbIYRfz4LQV68nyOQ2eEZqAuouGw=="
+            "version": "0.125.1",
+            "resolved": "https://registry.npmjs.org/super-three/-/super-three-0.125.1.tgz",
+            "integrity": "sha512-poTMpd0fa5tWVJDtWKSFWuqbb+h2Z0m1Eop66hRsfaeOE2p9xnl78MDJmj0S/jYI0Ly4iMQOWIkS0LyKCZe0SA=="
         },
         "node_modules/supports-color": {
             "version": "5.5.0",
@@ -25607,9 +25607,9 @@
             "integrity": "sha512-eOEXnZeE1FDV0XgL1u08auIP13jxdN9LQBAEmlErYzMxtIIfuGIAZbijOyookALUhqVzVOx0Tywj6n192VM+nQ=="
         },
         "node_modules/three-bmfont-text": {
-            "version": "2.4.0",
-            "resolved": "https://github.com/dmarcos/three-bmfont-text.git#21d017046216e318362c48abd1a48bddfb6e0733",
-            "integrity": "sha512-lIMa1n+QKNU1f/LZgtS1oUGpoop3MuVXrUr5ybZOUR3+Jk//zjqScnQpHml6MWyvZzL8A5/1Hd8Tsqd3M1kudA==",
+            "version": "2.3.0",
+            "resolved": "git+ssh://git@github.com/dmarcos/three-bmfont-text.git#1babdf8507c731a18f8af3b807292e2b9740955e",
+            "integrity": "sha512-1ACVhQynOX5fUHx9WY0leDApaQ8fa12wdU+z1iVRCiMDq5bZGw67kqUgEBrbK1BQ5awTZL3+VG3LX5xg+ty89Q==",
             "license": "MIT",
             "dependencies": {
                 "array-shuffle": "^1.0.1",
@@ -25623,7 +25623,7 @@
         },
         "node_modules/three-buffer-vertex-data": {
             "version": "1.1.0",
-            "resolved": "https://github.com/dmarcos/three-buffer-vertex-data.git#69378fc58daf27d3b1d930df9f233473e4a4818c",
+            "resolved": "git+ssh://git@github.com/dmarcos/three-buffer-vertex-data.git#69378fc58daf27d3b1d930df9f233473e4a4818c",
             "integrity": "sha512-ZPCCbGfueRzd2/YwH136UnVN+N11Mvxu7uPaEzIdtuk0m5HPs1LGXOM5hOkpxamjvqSC6MDJ3nd11grGi7sMKw==",
             "license": "MIT",
             "dependencies": {
@@ -25675,7 +25675,7 @@
         "node_modules/timed-out": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+            "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -26363,7 +26363,7 @@
         "node_modules/url-set-query": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-            "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
+            "integrity": "sha512-3AChu4NiXquPfeckE5R5cGdiHCMWJx1dwCWOmWIL4KHAziJNOFIYJlpGFeKDvwLPHovZRCxK3cYlwzqI9Vp+Gg=="
         },
         "node_modules/url/node_modules/punycode": {
             "version": "1.3.2",
@@ -27912,7 +27912,7 @@
         "node_modules/word-wrapper": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/word-wrapper/-/word-wrapper-1.0.7.tgz",
-            "integrity": "sha1-HxSv6/Zt/fD+9V79NxhO+9CMKLY="
+            "integrity": "sha512-VOPBFCm9b6FyYKQYfn9AVn2dQvdR/YOVFV6IBRA1TBMJWKffvhEX1af6FMGrttILs2Q9ikCRhLqkbY2weW6dOQ=="
         },
         "node_modules/workbox-background-sync": {
             "version": "5.1.4",
@@ -31727,9 +31727,9 @@
             }
         },
         "aframe": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/aframe/-/aframe-1.3.0.tgz",
-            "integrity": "sha512-f6OQaDf49SzdSxVskJPvPWldOwHpYMsGttmQHhU6FRiASsnyULKG1nqZom9pDuS3fFYEzQVqRMakQ2AhXeLkFg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aframe/-/aframe-1.2.0.tgz",
+            "integrity": "sha512-e4lGvxLQ5CAptlbCqmnR4+qUf9s3f5SSnkMQaBsIFlJ2QMZhzEBr/SSV3+NEvMhsQf88EOvSpN1Vez942mBLcQ==",
             "requires": {
                 "custom-event-polyfill": "^1.0.6",
                 "debug": "github:ngokevin/debug#noTimestamp",
@@ -31740,8 +31740,8 @@
                 "present": "0.0.6",
                 "promise-polyfill": "^3.1.0",
                 "super-animejs": "^3.1.0",
-                "super-three": "^0.137.0",
-                "three-bmfont-text": "github:dmarcos/three-bmfont-text#21d017046216e318362c48abd1a48bddfb6e0733",
+                "super-three": "^0.125.1",
+                "three-bmfont-text": "github:dmarcos/three-bmfont-text#1babdf8507c731a18f8af3b807292e2b9740955e",
                 "webvr-polyfill": "^0.10.12"
             }
         },
@@ -31857,7 +31857,7 @@
         "an-array": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/an-array/-/an-array-1.0.0.tgz",
-            "integrity": "sha1-wSWlu4JXd4419LT2qpx9D6nkJmU="
+            "integrity": "sha512-M175GYI7RmsYu24Ok383yZQa3eveDfNnmhTe3OQ3bm70bEovz2gWenH+ST/n32M8lrwLWk74hcPds5CDRPe2wg=="
         },
         "animejs": {
             "version": "2.2.0",
@@ -31993,7 +31993,7 @@
         "array-shuffle": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/array-shuffle/-/array-shuffle-1.0.1.tgz",
-            "integrity": "sha1-fqSIKjVrS8pfVF4LblLq9tlxVXo="
+            "integrity": "sha512-PBqgo1Y2XWSksBzq3GFPEb798ZrW2snAcmr4drbVeF/6MT/5aBlkGJEvu5A/CzXHf4EjbHOj/ZowatjlIiVidA=="
         },
         "array-union": {
             "version": "2.1.0",
@@ -32056,7 +32056,7 @@
         "as-number": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/as-number/-/as-number-1.0.0.tgz",
-            "integrity": "sha1-rLJ+NPj52KsNqeN287iVmGD4CmY="
+            "integrity": "sha512-HkI/zLo2AbSRO4fqVkmyf3hms0bJDs3iboHqTrNuwTiCRvdYXM7HFhfhB6Dk51anV2LM/IMB83mtK9mHw4FlAg=="
         },
         "asap": {
             "version": "2.0.6",
@@ -33320,7 +33320,7 @@
         "buffer-to-arraybuffer": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
-            "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
+            "integrity": "sha512-3dthu5CYiVB1DEJp61FtApNnNndTckcqe4pFcLdvHtrpG+kcyekCJKg4MRiDcFW7A6AODnXB9U4dwQiCW5kzJQ=="
         },
         "buffer-xor": {
             "version": "1.0.3",
@@ -34724,7 +34724,7 @@
             }
         },
         "debug": {
-            "version": "https://github.com/ngokevin/debug.git#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
+            "version": "git+ssh://git@github.com/ngokevin/debug.git#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
             "from": "debug@github:ngokevin/debug#noTimestamp"
         },
         "decamelize": {
@@ -34746,7 +34746,7 @@
         "decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
             "requires": {
                 "mimic-response": "^1.0.0"
             }
@@ -35129,7 +35129,7 @@
             }
         },
         "document-register-element": {
-            "version": "https://github.com/dmarcos/document-register-element.git#8ccc532b7f3744be954574caf3072a5fd260ca90",
+            "version": "git+ssh://git@github.com/dmarcos/document-register-element.git#8ccc532b7f3744be954574caf3072a5fd260ca90",
             "from": "document-register-element@github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90"
         },
         "dom-converter": {
@@ -35266,7 +35266,7 @@
         "dtype": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
-            "integrity": "sha1-zQUjI84GFETs0uj1dI9popvihDQ="
+            "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg=="
         },
         "duplexer": {
             "version": "0.1.2",
@@ -41702,7 +41702,7 @@
         "layout-bmfont-text": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/layout-bmfont-text/-/layout-bmfont-text-1.3.4.tgz",
-            "integrity": "sha1-8g8sVGR3T0jabOipl/vObUaUW4E=",
+            "integrity": "sha512-mceomHZ8W7pSKQhTdLvOe1Im4n37u8xa5Gr0J3KPCHRMO/9o7+goWIOzZcUUd+Xgzy3+22bvoIQ0OaN3LRtgaw==",
             "requires": {
                 "as-number": "^1.0.0",
                 "word-wrapper": "^1.0.7",
@@ -42060,7 +42060,7 @@
         "map-limit": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
-            "integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
+            "integrity": "sha512-pJpcfLPnIF/Sk3taPW21G/RQsEEirGaFpCW3oXRwH9dnFHPHNGjNyvh++rdmC2fNqEaTw2MhYJraoJWAHx8kEg==",
             "requires": {
                 "once": "~1.3.0"
             },
@@ -42068,7 +42068,7 @@
                 "once": {
                     "version": "1.3.3",
                     "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                    "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                    "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
                     "requires": {
                         "wrappy": "1"
                     }
@@ -42553,7 +42553,7 @@
         "new-array": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/new-array/-/new-array-1.0.0.tgz",
-            "integrity": "sha1-XbxjnZYerH8an7wacUbsEvKST78="
+            "integrity": "sha512-K5AyFYbuHZ4e/ti52y7k18q8UHsS78FlRd85w2Fmsd6AkuLipDihPflKC0p3PN5i8II7+uHxo+CtkLiJDfmS5A=="
         },
         "next-tick": {
             "version": "1.0.0",
@@ -42564,7 +42564,7 @@
         "nice-color-palettes": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/nice-color-palettes/-/nice-color-palettes-1.0.1.tgz",
-            "integrity": "sha1-h16gHchu+uf1leBmqLJmDnIGBT4=",
+            "integrity": "sha512-aHEFYKuGiaga8LqMi0Ttarqzn4tKS7BaIE2MeD9SDjv6yVc7DMIu/Eax4RvUgwR7vS0hXAUEIUx9P0/54O1W0g==",
             "requires": {
                 "map-limit": "0.0.1",
                 "minimist": "^1.2.0",
@@ -44976,7 +44976,7 @@
         "quad-indices": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/quad-indices/-/quad-indices-2.0.1.tgz",
-            "integrity": "sha1-ppQdiaE9Y+7WwdSlpiGgRjYXqBQ=",
+            "integrity": "sha512-6jtmCsEbGAh5npThXrBaubbTjPcF0rMbn57XCJVI7LkW8PUT56V+uIrRCCWCn85PSgJC9v8Pm5tnJDwmOBewvA==",
             "requires": {
                 "an-array": "^1.0.0",
                 "dtype": "^2.0.0",
@@ -48167,9 +48167,9 @@
             "integrity": "sha512-6MFAFJDRuvwkovxQZPruuyHinTa4rgj4hNLOndjcYYhZLckoXtVRY9rJPuq8p6c/tgZJrFYEAYAfJ2/hhNtUCA=="
         },
         "super-three": {
-            "version": "0.137.0",
-            "resolved": "https://registry.npmjs.org/super-three/-/super-three-0.137.0.tgz",
-            "integrity": "sha512-8jM8DiYiXQoalUoeFRxKWbW6KFQo3GFwgw+3vE2y6SJU/einw+JvuvgK+WhbIYRfz4LQV68nyOQ2eEZqAuouGw=="
+            "version": "0.125.1",
+            "resolved": "https://registry.npmjs.org/super-three/-/super-three-0.125.1.tgz",
+            "integrity": "sha512-poTMpd0fa5tWVJDtWKSFWuqbb+h2Z0m1Eop66hRsfaeOE2p9xnl78MDJmj0S/jYI0Ly4iMQOWIkS0LyKCZe0SA=="
         },
         "supports-color": {
             "version": "5.5.0",
@@ -48643,9 +48643,9 @@
             "integrity": "sha512-eOEXnZeE1FDV0XgL1u08auIP13jxdN9LQBAEmlErYzMxtIIfuGIAZbijOyookALUhqVzVOx0Tywj6n192VM+nQ=="
         },
         "three-bmfont-text": {
-            "version": "https://github.com/dmarcos/three-bmfont-text.git#21d017046216e318362c48abd1a48bddfb6e0733",
-            "integrity": "sha512-lIMa1n+QKNU1f/LZgtS1oUGpoop3MuVXrUr5ybZOUR3+Jk//zjqScnQpHml6MWyvZzL8A5/1Hd8Tsqd3M1kudA==",
-            "from": "three-bmfont-text@github:dmarcos/three-bmfont-text#21d017046216e318362c48abd1a48bddfb6e0733",
+            "version": "git+ssh://git@github.com/dmarcos/three-bmfont-text.git#1babdf8507c731a18f8af3b807292e2b9740955e",
+            "integrity": "sha512-1ACVhQynOX5fUHx9WY0leDApaQ8fa12wdU+z1iVRCiMDq5bZGw67kqUgEBrbK1BQ5awTZL3+VG3LX5xg+ty89Q==",
+            "from": "three-bmfont-text@github:dmarcos/three-bmfont-text#1babdf8507c731a18f8af3b807292e2b9740955e",
             "requires": {
                 "array-shuffle": "^1.0.1",
                 "inherits": "^2.0.1",
@@ -48657,7 +48657,7 @@
             }
         },
         "three-buffer-vertex-data": {
-            "version": "https://github.com/dmarcos/three-buffer-vertex-data.git#69378fc58daf27d3b1d930df9f233473e4a4818c",
+            "version": "git+ssh://git@github.com/dmarcos/three-buffer-vertex-data.git#69378fc58daf27d3b1d930df9f233473e4a4818c",
             "integrity": "sha512-ZPCCbGfueRzd2/YwH136UnVN+N11Mvxu7uPaEzIdtuk0m5HPs1LGXOM5hOkpxamjvqSC6MDJ3nd11grGi7sMKw==",
             "from": "three-buffer-vertex-data@dmarcos/three-buffer-vertex-data#69378fc58daf27d3b1d930df9f233473e4a4818c",
             "requires": {
@@ -48711,7 +48711,7 @@
         "timed-out": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+            "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA=="
         },
         "timers-browserify": {
             "version": "2.0.12",
@@ -49251,7 +49251,7 @@
         "url-set-query": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-            "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
+            "integrity": "sha512-3AChu4NiXquPfeckE5R5cGdiHCMWJx1dwCWOmWIL4KHAziJNOFIYJlpGFeKDvwLPHovZRCxK3cYlwzqI9Vp+Gg=="
         },
         "use": {
             "version": "3.1.1",
@@ -50526,7 +50526,7 @@
         "word-wrapper": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/word-wrapper/-/word-wrapper-1.0.7.tgz",
-            "integrity": "sha1-HxSv6/Zt/fD+9V79NxhO+9CMKLY="
+            "integrity": "sha512-VOPBFCm9b6FyYKQYfn9AVn2dQvdR/YOVFV6IBRA1TBMJWKffvhEX1af6FMGrttILs2Q9ikCRhLqkbY2weW6dOQ=="
         },
         "workbox-background-sync": {
             "version": "5.1.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "@engaging-computing/aframe-physics-system": "^4.0.0",
         "@material-ui/core": "^4.12.3",
-        "aframe": "^1.3.0",
+        "aframe": "1.2",
         "aframe-animation-component": "^5.0.0",
         "aframe-environment-component": "^1.3.1",
         "aframe-extras": "^4.1.2",


### PR DESCRIPTION
## Description
This PR downgrades AFrame from verison 1.3 to 1.2, this is to fix the current bug where VR and AR functionalities do not work on mobile.

Note: We previously merged this change into dev which resulted in a fail in the CI check due to a unknown host error.
