### PR TITLE
Reset button fix

### DIFF
--- a/src/components/structural/header/Header.js
+++ b/src/components/structural/header/Header.js
@@ -14,7 +14,6 @@ import * as layoutTypes from "../../../constants/LayoutTypes.js";
 
 import {
     Button,
-    ButtonBase,
     Icon,
     MenuItem,
     Tooltip,
@@ -34,15 +33,6 @@ const exitBtnStyle = {
     position: "absolute",
     top: 0,
     right: 0,
-};
-
-const resetButtonStyle = {
-    top: 2,
-    paddingLeft: 10,
-    paddingRight: 10,
-    color: "white",
-    opacity: 1
-
 };
 
 /**
@@ -808,15 +798,14 @@ class Header extends Component {
                             <Icon className="material-icons">save</Icon>
                         </IconButton>
                     </Tooltip>
-                    <Tooltip title="reset position" placement="bottom-start">
-                        <ButtonBase
+                    <Tooltip title="Reset Position" placement="bottom-start">
+                        <IconButton
                             id="reset-btn"
                             onClick={() => this.props.sceneActions.setCamera(0, 1.6, 3)}
-                            className="header-btn d-none d-md-block"
-                            style= {resetButtonStyle}
-                            disabled={referenceMode}>
-                            <Icon className ="material-icons">settings_backup_restore</Icon>  
-                        </ButtonBase>
+                            style={style.default}
+                            className="header-btn d-none d-md-block">
+                            <Icon className="material-icons">settings_backup_restore</Icon>  
+                        </IconButton>
                     </Tooltip> 
                     <ProjectView
                         deleteFunc={this.props.projectActions.deleteProj}

--- a/src/myr/tour.js
+++ b/src/myr/tour.js
@@ -39,6 +39,10 @@ export const TourSteps = [
         content: "Save your work.",
     },
     {
+        selector: "#reset-btn",
+        content: "Reset camera position."
+    },
+    {
         selector: "#open-btn",
         content: "See previous work and view examples.",
     },


### PR DESCRIPTION
## Description
This fixes the styling for the reset button. On production right now, the button has different margins and padding from the other buttons like the save, new scene and open buttons. This happened because the reset button had a different tag. Also, I added the reset button to the MYR tour. 

## Preview
before:
![image](https://github.com/engaging-computing/MYR/assets/53062712/96a1ddd2-0d95-476d-89f1-3a9b76ff2b77)
![image](https://github.com/engaging-computing/MYR/assets/53062712/e0f96a4e-90a4-40fc-b9b4-ab9b2aa0f79b)
after:
![image](https://github.com/engaging-computing/MYR/assets/53062712/d866bb35-8d8e-44f1-a5ae-158290853511)

The first image is used to show where the tooltip is normally. 